### PR TITLE
Make 'anonymous' names better

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for MooseX-Role-Parameterized
 
 {{$NEXT}}
+   - Give 'anonymous' generated roles names that are similar to the original
+     parameterized role so debug output is easier to read
 
 1.08      2014-08-23 22:38:12Z
     - add x_breaks metadata for incompatibility issue with MooseX::Storage

--- a/lib/MooseX/Role/Parameterized/Meta/Trait/Parameterizable.pm
+++ b/lib/MooseX/Role/Parameterized/Meta/Trait/Parameterizable.pm
@@ -48,6 +48,7 @@ sub _build_parameters_metaclass {
     );
 }
 
+my $package_counter = 0;
 sub generate_role {
     my $self     = shift;
     my %args     = @_;
@@ -62,19 +63,16 @@ sub generate_role {
     my $parameterized_role_metaclass = $self->parameterized_role_metaclass;
     use_module($parameterized_role_metaclass);
 
-    my $role;
-    if ($args{package}) {
-        $role = $parameterized_role_metaclass->create(
-            $args{package},
-            genitor    => $self,
-            parameters => $parameters,
-        );
-    } else {
-        $role = $parameterized_role_metaclass->create_anon_role(
-            genitor    => $self,
-            parameters => $parameters,
-        );
+    my $package = $args{package};
+    unless ($package) {
+        $package_counter++;
+        $package = $self->name . '::__ANON__::SERIAL::' . $package_counter;
     }
+    my $role = $parameterized_role_metaclass->create(
+        $package,
+        genitor    => $self,
+        parameters => $parameters,
+    );
 
     local $MooseX::Role::Parameterized::CURRENT_METACLASS = $role;
 

--- a/t/024-named-anonymous.t
+++ b/t/024-named-anonymous.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package Test::Role;
+    use MooseX::Role::Parameterized;
+
+    parameter default_beer => (
+        isa => "Str",
+        is  => "ro",
+        required => 1,
+    );
+
+    role {
+        my $p = shift;
+
+        has beer => (
+            isa => "Str",
+            is  => "ro",
+            default => $p->default_beer,
+        );
+    };
+
+    package Test::Class;
+    use Moose;
+
+    with 'Test::Role' => { default_beer => "O'Doul's" };
+
+    package Test::Class2;
+    use Moose;
+
+    with 'Test::Role' => { default_beer => "Root" };
+
+}
+
+like(
+    ($_->new->meta->calculate_all_roles)[0]->name,
+    qr/\ATest::Role::__ANON__::SERIAL::[0-9]+\z/,
+    "Right looking role name for $_",
+) for qw( Test::Class Test::Class2 );
+
+isnt(
+    (Test::Class->new->meta->calculate_all_roles)[0]->name,
+    (Test::Class2->new->meta->calculate_all_roles)[0]->name,
+    'role names are unique'
+);
+
+done_testing;


### PR DESCRIPTION
The 'anonymous' names for generated roles are now based on the original parameterized role that generated them, thus making debug output much easier to read